### PR TITLE
feat(#48): fix ESLint errors in shared components

### DIFF
--- a/src/components/shared/loading-spinner.test.tsx
+++ b/src/components/shared/loading-spinner.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { describe, it, expect, afterEach } from "vitest"
+import { LoadingSpinner } from "./loading-spinner"
+
+afterEach(cleanup)
+
+describe("LoadingSpinner", () => {
+  it("renders with default size", () => {
+    render(<LoadingSpinner />)
+    const spinner = screen.getByRole("status")
+    expect(spinner).toBeInTheDocument()
+    expect(spinner.getAttribute("class")).toContain("size-6")
+  })
+
+  it("renders with large size", () => {
+    render(<LoadingSpinner size="lg" />)
+    const spinner = screen.getByRole("status")
+    expect(spinner.getAttribute("class")).toContain("size-8")
+  })
+
+  it("renders with small size", () => {
+    render(<LoadingSpinner size="sm" />)
+    const spinner = screen.getByRole("status")
+    expect(spinner.getAttribute("class")).toContain("size-4")
+  })
+
+  it("has accessible label", () => {
+    render(<LoadingSpinner />)
+    expect(screen.getByRole("status")).toHaveAttribute("aria-label", "Loading")
+  })
+
+  it("contains an animated element", () => {
+    render(<LoadingSpinner />)
+    const spinner = screen.getByRole("status")
+    expect(spinner.getAttribute("class")).toContain("animate-spin")
+  })
+})

--- a/src/components/shared/loading-spinner.tsx
+++ b/src/components/shared/loading-spinner.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils"
+
+const sizeClasses = {
+  sm: "size-4",
+  md: "size-6",
+  lg: "size-8",
+} as const
+
+interface LoadingSpinnerProps {
+  size?: keyof typeof sizeClasses
+  className?: string
+}
+
+export function LoadingSpinner({
+  size = "md",
+  className,
+}: LoadingSpinnerProps) {
+  return (
+    <svg
+      role="status"
+      aria-label="Loading"
+      className={cn(
+        "animate-spin text-muted-foreground",
+        sizeClasses[size],
+        className,
+      )}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}

--- a/src/components/shared/status-badge.test.tsx
+++ b/src/components/shared/status-badge.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { describe, it, expect, afterEach } from "vitest"
+import { StatusBadge } from "./status-badge"
+
+afterEach(cleanup)
+
+describe("StatusBadge", () => {
+  it("renders the status text", () => {
+    render(<StatusBadge status="live" />)
+    expect(screen.getByText("live")).toBeInTheDocument()
+  })
+
+  it("applies red styling for live status", () => {
+    render(<StatusBadge status="live" />)
+    expect(screen.getByText("live").className).toContain("bg-red")
+  })
+
+  it("applies gray styling for completed status", () => {
+    render(<StatusBadge status="completed" />)
+    expect(screen.getByText("completed").className).toContain("bg-gray")
+  })
+
+  it("applies green styling for upcoming status", () => {
+    render(<StatusBadge status="upcoming" />)
+    expect(screen.getByText("upcoming").className).toContain("bg-green")
+  })
+
+  it("applies yellow styling for registration_open status", () => {
+    render(<StatusBadge status="registration_open" />)
+    expect(screen.getByText("registration_open").className).toContain("bg-yellow")
+  })
+
+  it("applies blue styling for in_progress status", () => {
+    render(<StatusBadge status="in_progress" />)
+    expect(screen.getByText("in_progress").className).toContain("bg-blue")
+  })
+
+  it("handles unknown status values with fallback style", () => {
+    render(<StatusBadge status={"something_else"} />)
+    expect(screen.getByText("something_else").className).toContain("bg-gray")
+  })
+})

--- a/src/components/shared/status-badge.tsx
+++ b/src/components/shared/status-badge.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils"
+
+const statusColors: Record<string, string> = {
+  live: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  completed: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300",
+  upcoming: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  registration_open:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+  in_progress: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+}
+
+const fallbackColor =
+  "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300"
+
+interface StatusBadgeProps {
+  status: string
+  className?: string
+}
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        statusColors[status] ?? fallbackColor,
+        className,
+      )}
+    >
+      {status}
+    </span>
+  )
+}

--- a/src/components/shared/team-logo.test.tsx
+++ b/src/components/shared/team-logo.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { describe, it, expect, afterEach } from "vitest"
+import { TeamLogo } from "./team-logo"
+
+afterEach(cleanup)
+
+describe("TeamLogo", () => {
+  it("renders img tag when logo_url is provided", () => {
+    render(<TeamLogo name="Nepal FC" logoUrl="https://example.com/logo.png" />)
+    const img = screen.getByRole("img", { name: "Nepal FC logo" })
+    expect(img).toBeInTheDocument()
+    expect(img.tagName).toBe("IMG")
+    expect(img).toHaveAttribute("src", "https://example.com/logo.png")
+  })
+
+  it("renders initials fallback when logo_url is null", () => {
+    render(<TeamLogo name="Nepal FC" logoUrl={null} />)
+    expect(screen.queryByTagName?.("img") ?? screen.queryByRole("img", { name: "Nepal FC logo" })).toBeInTheDocument()
+    expect(screen.getByText("N")).toBeInTheDocument()
+  })
+
+  it("renders initials fallback when logo_url is undefined", () => {
+    render(<TeamLogo name="Kathmandu Warriors" />)
+    const el = screen.getByLabelText("Kathmandu Warriors logo")
+    expect(el.tagName).not.toBe("IMG")
+    expect(screen.getByText("K")).toBeInTheDocument()
+  })
+
+  it("handles empty team name gracefully", () => {
+    render(<TeamLogo name="" logoUrl={null} />)
+    const fallback = screen.getByLabelText("Team logo")
+    expect(fallback).toBeInTheDocument()
+  })
+
+  it("has accessible aria label", () => {
+    render(<TeamLogo name="Nepal FC" logoUrl={null} />)
+    expect(screen.getByLabelText("Nepal FC logo")).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/team-logo.tsx
+++ b/src/components/shared/team-logo.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image"
+import { cn } from "@/lib/utils"
+
+interface TeamLogoProps {
+  name: string
+  logoUrl?: string | null
+  size?: number
+  className?: string
+}
+
+export function TeamLogo({
+  name,
+  logoUrl,
+  size = 40,
+  className,
+}: TeamLogoProps) {
+  const initial = name.charAt(0).toUpperCase()
+  const label = name ? `${name} logo` : "Team logo"
+
+  if (logoUrl) {
+    return (
+      <Image
+        src={logoUrl}
+        alt={label}
+        width={size}
+        height={size}
+        unoptimized
+        className={cn("rounded-full object-cover", className)}
+      />
+    )
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      style={{ width: size, height: size }}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground",
+        className,
+      )}
+    >
+      {initial || null}
+    </div>
+  )
+}

--- a/src/lib/supabase/__tests__/server.test.ts
+++ b/src/lib/supabase/__tests__/server.test.ts
@@ -25,7 +25,7 @@ describe("createServerClient", () => {
       getAll: vi.fn().mockReturnValue([]),
       set: vi.fn(),
     };
-    vi.mocked(cookies).mockResolvedValue(mockCookieStore as any);
+    vi.mocked(cookies).mockResolvedValue(mockCookieStore as unknown as Awaited<ReturnType<typeof cookies>>);
 
     const { createServerClient } = await import("@/lib/supabase/server");
     const client = await createServerClient();
@@ -40,7 +40,7 @@ describe("createServerClient", () => {
       getAll: vi.fn().mockReturnValue([]),
       set: vi.fn(),
     };
-    vi.mocked(cookies).mockResolvedValue(mockCookieStore as any);
+    vi.mocked(cookies).mockResolvedValue(mockCookieStore as unknown as Awaited<ReturnType<typeof cookies>>);
 
     const { createServerClient } = await import("@/lib/supabase/server");
     const client1 = await createServerClient();
@@ -71,7 +71,7 @@ describe("createServerClient", () => {
       getAll: vi.fn().mockReturnValue(mockCookies),
       set: vi.fn(),
     };
-    vi.mocked(cookies).mockResolvedValue(mockCookieStore as any);
+    vi.mocked(cookies).mockResolvedValue(mockCookieStore as unknown as Awaited<ReturnType<typeof cookies>>);
 
     const { createServerClient } = await import("@/lib/supabase/server");
     const client = await createServerClient();


### PR DESCRIPTION
## Summary
Fixes the ESLint regression reported in #48 after merge of PR #46.

- **status-badge.test.tsx**: Removed unnecessary `as any` cast — `status` prop is already typed as `string`, so casting to `any` for an unknown value test is redundant
- **team-logo.tsx**: Replaced `<img>` with Next.js `<Image>` component (with `unoptimized` for external URLs) to resolve `@next/next/no-img-element` warning
- **server.test.ts**: Replaced `as any` with `as unknown as Awaited<ReturnType<typeof cookies>>` for proper type-safe mock assertions
- **All component test files**: Added `// @vitest-environment jsdom` directives and `@testing-library/jest-dom/vitest` imports so component tests run in the correct DOM environment without changing the global vitest config

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 26/26 tests pass (5 test files)
- [ ] `npm run build` — verify production build succeeds

## DECISIONS.md

| Decision | Rationale |
|----------|-----------|
| Per-file `@vitest-environment jsdom` instead of global config change | Avoids breaking server-side tests that need `node` environment |
| `<Image unoptimized>` for team logos | External URLs don't have `remotePatterns` configured; `unoptimized` skips the image optimization proxy while satisfying the ESLint rule |
| `as unknown as Type` instead of `as any` | Satisfies `@typescript-eslint/no-explicit-any` while maintaining type safety through double assertion |

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)